### PR TITLE
Performance optimisation: Reuse workspace between discovery and execution tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NUCLEUS_DOCKER_FILE ?= ./build/nucleus/Dockerfile
-NUCLEUS_IMAGE_NAME ?= nucleus
+NUCLEUS_IMAGE_NAME ?= lambdatest/nucleus:latest
 
 SYNAPSE_DOCKER_FILE ?= ./build/synapse/Dockerfile
 SYNAPSE_IMAGE_NAME ?= lambdatest/synapse:latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NUCLEUS_DOCKER_FILE ?= ./build/nucleus/Dockerfile
-NUCLEUS_IMAGE_NAME ?= lambdatest/nucleus:latest
+NUCLEUS_IMAGE_NAME ?= nucleus
 
 SYNAPSE_DOCKER_FILE ?= ./build/synapse/Dockerfile
 SYNAPSE_IMAGE_NAME ?= lambdatest/synapse:latest

--- a/build/nucleus/Dockerfile
+++ b/build/nucleus/Dockerfile
@@ -43,12 +43,7 @@ RUN su - nucleus -c "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39
 
 WORKDIR /home/nucleus
 # copy the binary from builder
-COPY --chown=nucleus:nucleus --from=builder /nucleus/nucleus .
-COPY --chown=nucleus:nucleus sample-tas.yaml .
-COPY --chown=nucleus:nucleus scripts/ /scripts
-RUN cd /scripts && npm i
-RUN touch .nucleus.yml
-
+COPY --chown=nucleus:nucleus --from=builder /nucleus/nucleus /usr/local/bin/
 # run the binary
 COPY ./build/nucleus/entrypoint.sh /
 ENTRYPOINT  ["/bin/sh", "/entrypoint.sh"]

--- a/build/nucleus/entrypoint.sh
+++ b/build/nucleus/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-chown -R nucleus:nucleus /coverage 2>/dev/null
-exec runuser -u nucleus -- /home/nucleus/nucleus "$@"
+chown -R nucleus:nucleus /home/nucleus 2>/dev/null
+exec runuser -u nucleus -- /usr/local/bin/nucleus "$@"

--- a/build/nucleus/entrypoint.sh
+++ b/build/nucleus/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-chown -R nucleus:nucleus /home/nucleus 2>/dev/null
+chown -R nucleus:nucleus /workspace-cache 2>/dev/null
 exec runuser -u nucleus -- /usr/local/bin/nucleus "$@"

--- a/pkg/core/interfaces.go
+++ b/pkg/core/interfaces.go
@@ -99,6 +99,10 @@ type CacheStore interface {
 	Download(ctx context.Context, cacheKey string) error
 	// Upload creates, compresses and uploads cache at cacheKey
 	Upload(ctx context.Context, cacheKey string, itemsToCompress ...string) error
+	// CacheWorkspace caches the workspace onto a mounted volume
+	CacheWorkspace(ctx context.Context) error
+	// ExtractWorkspace extracts the workspace cache from mounted volume
+	ExtractWorkspace(ctx context.Context) error
 }
 
 // SecretParser defines operation for parsing the vault secrets in given path

--- a/pkg/core/lifecycle.go
+++ b/pkg/core/lifecycle.go
@@ -211,14 +211,14 @@ func (pl *Pipeline) Start(ctx context.Context) (err error) {
 		err = pl.TestBlockListService.GetBlockListedTests(ctx, tasConfig, payload.RepoID)
 		if err != nil {
 			pl.Logger.Errorf("Unable to fetch blocklisted tests: %v", err)
-			errRemark = errs.GenericUserFacingBEErrRemark
+			errRemark = errs.GenericErrRemark.Error()
 			return err
 		}
 
 		// TODO:  download from cdn
 		if err = pl.CacheStore.Download(ctx, cacheKey); err != nil {
 			pl.Logger.Errorf("Unable to download cache: %v", err)
-			errRemark = errs.GenericUserFacingBEErrRemark
+			errRemark = errs.GenericErrRemark.Error()
 			return err
 		}
 
@@ -234,7 +234,7 @@ func (pl *Pipeline) Start(ctx context.Context) (err error) {
 		err = pl.ExecutionManager.ExecuteInternalCommands(ctx, InstallRunners, global.InstallRunnerCmd, global.RepoDir, nil, nil)
 		if err != nil {
 			pl.Logger.Errorf("Unable to install custom runners %v", err)
-			errRemark = errs.GenericUserFacingBEErrRemark
+			errRemark = errs.GenericErrRemark.Error()
 			return err
 		}
 
@@ -259,7 +259,7 @@ func (pl *Pipeline) Start(ctx context.Context) (err error) {
 		// Upload cache once for other builds
 		if err = pl.CacheStore.Upload(ctx, cacheKey, tasConfig.Cache.Paths...); err != nil {
 			pl.Logger.Errorf("Unable to upload cache: %v", err)
-			errRemark = errs.GenericUserFacingBEErrRemark
+			errRemark = errs.GenericErrRemark.Error()
 			return err
 		}
 		pl.Logger.Debugf("Cache uploaded successfully")

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -76,7 +76,7 @@ func CopyDir(src, dst string, changeMode bool) (err error) {
 		return
 	}
 	if err == nil {
-		return fmt.Errorf("destination already exists")
+		return fmt.Errorf("destination %+v already exists", dst)
 	}
 
 	err = os.MkdirAll(dst, si.Mode())

--- a/pkg/global/nucleusconstants.go
+++ b/pkg/global/nucleusconstants.go
@@ -4,16 +4,16 @@ import "time"
 
 // All constant related to nucleus
 const (
-	CodeCoveragParentDir     = "/coverage"
 	CoverageManifestFileName = "manifest.json"
 	HomeDir                  = "/home/nucleus"
 	RepoDir                  = HomeDir + "/repo"
+	CodeCoverageDir          = RepoDir + "/coverage"
 	DefaultHTTPTimeout       = 45 * time.Second
 	SamplingTime             = 5 * time.Millisecond
 	RepoSecretPath           = "/vault/secrets/reposecrets"
 	OauthSecretPath          = "/vault/secrets/oauth"
 	NeuronRemoteHost         = "http://neuron-service.phoenix"
-	BlocklistedFileLocation  = "/scripts/blocklist.json"
+	BlocklistedFileLocation  = RepoDir + "/blocklist.json"
 	SecretRegex              = `\${{\s*secrets\.(.*?)\s*}}`
 	ExecutionResultChunkSize = 50
 	TestLocatorsDelimiter    = "#TAS#"

--- a/pkg/global/nucleusconstants.go
+++ b/pkg/global/nucleusconstants.go
@@ -6,6 +6,7 @@ import "time"
 const (
 	CoverageManifestFileName = "manifest.json"
 	HomeDir                  = "/home/nucleus"
+	WorkspaceCacheDir        = "/workspace-cache"
 	RepoDir                  = HomeDir + "/repo"
 	CodeCoverageDir          = RepoDir + "/coverage"
 	DefaultHTTPTimeout       = 45 * time.Second

--- a/pkg/runner/docker/config.go
+++ b/pkg/runner/docker/config.go
@@ -17,9 +17,9 @@ import (
 
 const (
 	networkName                = "test-at-scale"
-	defaultContainerVolumePath = "/coverage"
+	defaultContainerVolumePath = "/home/nucleus"
 	defaultVaultPath           = "/vault/secrets"
-	coverageSourcePath         = "/tmp/synapse/coverage"
+	repoSourcePath             = "/tmp/synapse/nucleus"
 	nanoCPUUnit                = 1e9
 	// GB defines number of bytes in 1 GB
 	GB int64 = 1e+9
@@ -85,7 +85,7 @@ func (d *docker) PullImage(containerImageConfig *core.ContainerImageConfig) erro
 }
 
 func (d *docker) getContainerHostConfiguration(r *core.RunnerOptions) *container.HostConfig {
-	if err := utils.CreateDirectory(coverageSourcePath); err != nil {
+	if err := utils.CreateDirectory(repoSourcePath); err != nil {
 		d.logger.Errorf("error creating directory: %v", err)
 	}
 	specs := getSpces(r.Tier)
@@ -99,7 +99,7 @@ func (d *docker) getContainerHostConfiguration(r *core.RunnerOptions) *container
 		Mounts: []mount.Mount{
 			{
 				Type:   mount.TypeBind,
-				Source: coverageSourcePath,
+				Source: repoSourcePath,
 				Target: defaultContainerVolumePath,
 			},
 			{

--- a/pkg/runner/docker/config.go
+++ b/pkg/runner/docker/config.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/LambdaTest/synapse/config"
 	"github.com/LambdaTest/synapse/pkg/core"
+	"github.com/LambdaTest/synapse/pkg/global"
 	"github.com/LambdaTest/synapse/pkg/synapse"
 	"github.com/LambdaTest/synapse/pkg/utils"
 	"github.com/docker/docker/api/types"
@@ -18,11 +19,10 @@ import (
 )
 
 const (
-	networkName                = "test-at-scale"
-	defaultContainerVolumePath = "/home/nucleus"
-	defaultVaultPath           = "/vault/secrets"
-	repoSourcePath             = "/tmp/synapse/%s/nucleus"
-	nanoCPUUnit                = 1e9
+	networkName      = "test-at-scale"
+	defaultVaultPath = "/vault/secrets"
+	repoSourcePath   = "/tmp/synapse/%s/nucleus"
+	nanoCPUUnit      = 1e9
 	// GB defines number of bytes in 1 GB
 	GB int64 = 1e+9
 )
@@ -109,7 +109,7 @@ func (d *docker) getContainerHostConfiguration(r *core.RunnerOptions) *container
 		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeBind,
 			Source: repoBuildSourcePath,
-			Target: defaultContainerVolumePath,
+			Target: global.WorkspaceCacheDir,
 		})
 	}
 	return &container.HostConfig{

--- a/pkg/service/coverage/coverage.go
+++ b/pkg/service/coverage/coverage.go
@@ -53,7 +53,7 @@ func New(execManager core.ExecutionManager,
 	if !cfg.CoverageMode {
 		return nil, nil
 	}
-	if _, err := os.Stat(global.CodeCoveragParentDir); os.IsNotExist(err) {
+	if _, err := os.Stat(global.CodeCoverageDir); os.IsNotExist(err) {
 		return nil, errors.New("coverage directory not mounted")
 	}
 	return &codeCoverageService{
@@ -61,7 +61,7 @@ func New(execManager core.ExecutionManager,
 		execManager:          execManager,
 		azureClient:          azureClient,
 		zstd:                 zstd,
-		codeCoveragParentDir: global.CodeCoveragParentDir,
+		codeCoveragParentDir: global.CodeCoverageDir,
 		endpoint:             global.NeuronHost + "/coverage",
 		httpClient: http.Client{
 			Timeout: global.DefaultHTTPTimeout,

--- a/pkg/testdiscoveryservice/testdiscovery.go
+++ b/pkg/testdiscoveryservice/testdiscovery.go
@@ -51,10 +51,15 @@ func (tds *testDiscoveryService) Discover(ctx context.Context,
 
 	args := []string{"--command", "discover"}
 	if !discoverAll {
-		for k, v := range diff {
-			// in changed files we only have added or modified files.
-			if v != core.FileRemoved {
-				args = append(args, "--diff", k)
+		if len(diff) == 0 {
+			// empty diff; in PR, a commit added and then reverted to cause an overall empty PR diff
+			args = append(args, "--diff")
+		} else {
+			for k, v := range diff {
+				// in changed files we only have added or modified files.
+				if v != core.FileRemoved {
+					args = append(args, "--diff", k)
+				}
 			}
 		}
 	}

--- a/pkg/zstd/zstd.go
+++ b/pkg/zstd/zstd.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/LambdaTest/synapse/pkg/core"
-	"github.com/LambdaTest/synapse/pkg/global"
 	"github.com/LambdaTest/synapse/pkg/lumber"
 )
 
@@ -49,7 +48,7 @@ func (z *zstdCompressor) Compress(ctx context.Context, compressedFileName string
 	if preservePath {
 		args = append(args, "-P")
 	}
-	if err := z.execManager.ExecuteInternalCommands(ctx, core.Zstd, args, global.RepoDir, nil, nil); err != nil {
+	if err := z.execManager.ExecuteInternalCommands(ctx, core.Zstd, args, workingDirectory, nil, nil); err != nil {
 		z.logger.Errorf("error while zstd compression %v", err)
 		return err
 	}
@@ -62,7 +61,7 @@ func (z *zstdCompressor) Decompress(ctx context.Context, filePath string, preser
 	if preservePath {
 		args = append(args, "-P")
 	}
-	if err := z.execManager.ExecuteInternalCommands(ctx, core.Zstd, args, global.RepoDir, nil, nil); err != nil {
+	if err := z.execManager.ExecuteInternalCommands(ctx, core.Zstd, args, workingDirectory, nil, nil); err != nil {
 		z.logger.Errorf("error while zstd decompression %v", err)
 		return err
 	}


### PR DESCRIPTION
# Description

Performance optimisation: Reused workspace between discovery and execution tasks. Previously, we used to run the preRun commands again in `execution` mode of nucleus. With this change, `execute` tasks start using the workspace already set up by `discover` task.

Fixes # (issue)
Reduces the preRun setup latency contribution by half.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested locally with an `express` webhook. Observed that all tests ran successfully and test-execution phase continued on the workspace created by test-discovery phase

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
