### PR TITLE
added support for synpase name via config

### DIFF
--- a/.sample.synapse.json
+++ b/.sample.synapse.json
@@ -1,5 +1,5 @@
 {
-    "name": "syanpse-1",
+    "name": "synapse-1",
     "logConfig": {
       "enableConsole": true,
       "consolelevel": "debug"

--- a/.sample.synapse.json
+++ b/.sample.synapse.json
@@ -1,4 +1,5 @@
 {
+    "name": "syanpse-1",
     "logConfig": {
       "enableConsole": true,
       "consolelevel": "debug"

--- a/config/synapsemodel.go
+++ b/config/synapsemodel.go
@@ -6,6 +6,7 @@ import "github.com/LambdaTest/synapse/pkg/lumber"
 
 // SynapseConfig the application's configuration
 type SynapseConfig struct {
+	Name              string
 	Config            string
 	LogFile           string
 	LogConfig         lumber.LoggingConfig

--- a/pkg/core/secrets.go
+++ b/pkg/core/secrets.go
@@ -23,4 +23,6 @@ type SecretsManager interface {
 
 	// GetDockerSecrets returns Mode , RegistryAuth, and URL for pulling remote docker image
 	GetDockerSecrets(r *RunnerOptions) (ContainerImageConfig, error)
+	// GetSynapseName returns synapse name mentioned in config
+	GetSynapseName() string
 }

--- a/pkg/core/wsproto.go
+++ b/pkg/core/wsproto.go
@@ -42,6 +42,7 @@ type Message struct {
 
 // LoginDetails struct
 type LoginDetails struct {
+	Name      string  `json:"name"`
 	SynapseID string  `json:"synapse_id"`
 	SecretKey string  `json:"secret_key"`
 	CPU       float32 `json:"cpu"`

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -34,6 +34,10 @@ func (s *secertManager) GetLambdatestSecrets() *config.LambdatestConfig {
 	return &s.cfg.Lambdatest
 }
 
+func (s *secertManager) GetSynapseName() string {
+	return s.cfg.Name
+}
+
 func (s *secertManager) WriteGitSecrets(path string) error {
 	gitSecrets := secretsFile{
 		Secrets: core.Secret{

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -34,6 +34,7 @@ func (s *secertManager) GetLambdatestSecrets() *config.LambdatestConfig {
 	return &s.cfg.Lambdatest
 }
 
+// GetSynapseName returns the name of synapse if mentioned in config
 func (s *secertManager) GetSynapseName() string {
 	return s.cfg.Name
 }

--- a/pkg/synapse/synapse.go
+++ b/pkg/synapse/synapse.go
@@ -118,7 +118,7 @@ func (s *synapse) openAndMaintainConnection(ctx context.Context, connectionFaile
 
 /*
  connectionHandler handles the connection by listening to any connection closer
- also it returns boolean value which repersents whether we can retry to connect
+ also it returns boolean value which represents whether we can retry to connect
 */
 func (s *synapse) connectionHandler(ctx context.Context, conn *websocket.Conn, connectionFailed chan struct{}) bool {
 	normalCloser := make(chan struct{})
@@ -183,7 +183,7 @@ func (s *synapse) messageReader(normalCloser chan struct{}, conn *websocket.Conn
 	}
 }
 
-// processMessage process messages recieved via websocket
+// processMessage process messages received via websocket
 func (s *synapse) processMessage(msg []byte) {
 	var message core.Message
 	err := json.Unmarshal(msg, &message)

--- a/pkg/synapse/synapse.go
+++ b/pkg/synapse/synapse.go
@@ -279,6 +279,7 @@ func (s *synapse) login() {
 	}
 	lambdatestConfig := s.secretsManager.GetLambdatestSecrets()
 	loginDetails := core.LoginDetails{
+		Name:      s.secretsManager.GetSynapseName(),
 		SecretKey: lambdatestConfig.SecretKey,
 		CPU:       cpu,
 		RAM:       ram,


### PR DESCRIPTION
# Issue Link
https://lambdatest.atlassian.net/browse/PHX-2647

# Description

This PR contains the following changes 
- For parsing and passing synapse name from config `.synapse.json` to lambdatest server. The name is optional in config.
- Fix failing go lint checks 
Related PR https://github.com/LambdaTest/neuron/pull/397

Fixes # (issue)
https://github.com/LambdaTest/test-at-scale/issues/85#issue-1180435183
- For parsing and passing synapse name from config `.synapse.json` to lambdatest server. The name is optional in config.
- Fix failing go lint checks 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested locally  

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
