### PR TITLE
Corrected status of tasks.

### DIFF
--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -178,7 +178,7 @@ func (s *Store) GetSASURL(ctx context.Context, containerPath string, containerTy
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		s.logger.Errorf("error while getting SAS Token, status code %d", resp.StatusCode)
-		return "", errs.ErrApiStatus
+		return "", errs.ErrAPIStatus
 	}
 
 	rawBytes, err := ioutil.ReadAll(resp.Body)

--- a/pkg/errs/nucleus.go
+++ b/pkg/errs/nucleus.go
@@ -51,8 +51,8 @@ var (
 	ErrSASToken = New("azure client requires SAS Token")
 	// ErrAzureCredentials is returned when the azure credentials are invalid.
 	ErrAzureCredentials = New("azure client requires credentials")
-	// ErrApiStatus is returned when the api status is not 200.
-	ErrApiStatus = New("non OK status")
+	// ErrAPIStatus is returned when the api status is not 200.
+	ErrAPIStatus = New("non OK status")
 	// ErrInvalidLoggerInstance is returned when logger instance is not supported.
 	ErrInvalidLoggerInstance = New("Invalid logger instance")
 	// ErrUnsupportedGitProvider is returned when try to integrate unsupported provider repo
@@ -62,3 +62,11 @@ var (
 	// GenericErrRemark returns a generic error message for user facing errors.
 	GenericErrRemark = New("Unexpected error")
 )
+
+type StatusFailed struct {
+	Remark string
+}
+
+func (e *StatusFailed) Error() string {
+	return e.Remark
+}

--- a/pkg/gitmanager/setup.go
+++ b/pkg/gitmanager/setup.go
@@ -89,7 +89,7 @@ func (gm *gitManager) downloadFile(ctx context.Context, archiveURL, fileName str
 
 	if resp.StatusCode != http.StatusOK {
 		gm.logger.Errorf("non 200 status while cloning from endpoint %s, status %d ", archiveURL, resp.StatusCode)
-		return errs.ErrApiStatus
+		return errs.ErrAPIStatus
 	}
 	err = gm.copyAndExtractFile(resp, fileName)
 	if err != nil {

--- a/pkg/service/teststats/teststats.go
+++ b/pkg/service/teststats/teststats.go
@@ -19,7 +19,7 @@ type ProcStats struct {
 	httpClient                   http.Client
 	ExecutionResultInputChannel  chan core.ExecutionResults
 	wg                           sync.WaitGroup
-	ExecutionResultOutputChannel chan core.ExecutionResults
+	ExecutionResultOutputChannel chan *core.ExecutionResults
 }
 
 // New returns instance of ProcStats
@@ -30,7 +30,7 @@ func New(cfg *config.NucleusConfig, logger lumber.Logger) (*ProcStats, error) {
 		httpClient: http.Client{
 			Timeout: global.DefaultHTTPTimeout,
 		},
-		ExecutionResultOutputChannel: make(chan core.ExecutionResults),
+		ExecutionResultOutputChannel: make(chan *core.ExecutionResults),
 	}, nil
 
 }
@@ -60,13 +60,13 @@ func (s *ProcStats) CaptureTestStats(pid int32, collectStats bool) error {
 					s.appendStatsToTestSuites(executionResults.Results[ind].TestSuitePayload, processStats)
 				}
 			}
-			s.ExecutionResultOutputChannel <- executionResults
+			s.ExecutionResultOutputChannel <- &executionResults
 		default:
 			// Can reach here in 2 cases (ie `/results` API wasn't called):
 			// 1. runner process exited with zero exit exitCode but no testFiles were run (changes in Readme.md etc)
 			// 2. runner process exited with non-zero exitCode
 			s.logger.Warnf("No test results found, pid %d", pid)
-			s.ExecutionResultOutputChannel <- core.ExecutionResults{}
+			s.ExecutionResultOutputChannel <- nil
 		}
 	}()
 

--- a/pkg/service/teststats/teststats.go
+++ b/pkg/service/teststats/teststats.go
@@ -65,8 +65,6 @@ func (s *ProcStats) CaptureTestStats(pid int32, collectStats bool) error {
 			// Can reach here in 2 cases (ie `/results` API wasn't called):
 			// 1. runner process exited with zero exit exitCode but no testFiles were run (changes in Readme.md etc)
 			// 2. runner process exited with non-zero exitCode
-			// In second case, non-zero exitCodes are already captured and sent as
-			// "Task error" when updating task status to neuron in lifeycle.go
 			s.logger.Warnf("No test results found, pid %d", pid)
 			s.ExecutionResultOutputChannel <- core.ExecutionResults{}
 		}

--- a/pkg/service/teststats/teststats_test.go
+++ b/pkg/service/teststats/teststats_test.go
@@ -53,7 +53,7 @@ func TestNew(t *testing.T) {
 					Timeout: global.DefaultHTTPTimeout,
 				},
 				ExecutionResultInputChannel:  make(chan core.ExecutionResults),
-				ExecutionResultOutputChannel: make(chan core.ExecutionResults),
+				ExecutionResultOutputChannel: make(chan *core.ExecutionResults),
 			}, false},
 	}
 	for _, tt := range tests {

--- a/pkg/testexecutionservice/testexecution.go
+++ b/pkg/testexecutionservice/testexecution.go
@@ -132,7 +132,7 @@ func (tes *testExecutionService) Run(ctx context.Context,
 	// 		return nil, err
 	// 	}
 	// }
-	return &executionResults, errC
+	return executionResults, errC
 }
 
 // func (tes *testExecutionService) createCoverageManifest(tasConfig *core.TASConfig, coverageDirectory string, removedFiles []string, executeAll bool) error {

--- a/pkg/testexecutionservice/testexecution.go
+++ b/pkg/testexecutionservice/testexecution.go
@@ -135,15 +135,6 @@ func (tes *testExecutionService) Run(ctx context.Context,
 	return &executionResults, errC
 }
 
-func (tes *testExecutionService) closeAndWriteLog(azureWriter *io.PipeWriter, errChan <-chan error) error {
-	azureWriter.Close()
-	if err := <-errChan; err != nil {
-		tes.logger.Errorf("failed to upload logs for test execution, error: %v", err)
-		return err
-	}
-	return nil
-}
-
 // func (tes *testExecutionService) createCoverageManifest(tasConfig *core.TASConfig, coverageDirectory string, removedFiles []string, executeAll bool) error {
 // 	manifestFile := core.CoverageManifest{
 // 		Removedfiles:     removedFiles,
@@ -201,4 +192,11 @@ func (tes *testExecutionService) GetLocatorsFile(ctx context.Context, locatorAdd
 		return "", err
 	}
 	return locatorFilePath, err
+}
+
+func (tes *testExecutionService) closeAndWriteLog(azureWriter *io.PipeWriter, errChan <-chan error) {
+	azureWriter.Close()
+	if err := <-errChan; err != nil {
+		tes.logger.Errorf("failed to upload logs for test execution, error: %v", err)
+	}
 }

--- a/pkg/testexecutionservice/testexecution.go
+++ b/pkg/testexecutionservice/testexecution.go
@@ -49,8 +49,8 @@ func (tes *testExecutionService) Run(ctx context.Context,
 	defer azureWriter.Close()
 	blobPath := fmt.Sprintf("%s/%s/%s/%s.log", payload.OrgID, payload.BuildID, payload.TaskID, core.Execution)
 	errChan := tes.execManager.StoreCommandLogs(ctx, blobPath, azureReader)
+	defer tes.closeAndWriteLog(azureWriter, errChan)
 	logWriter := lumber.NewWriter(tes.logger)
-	defer logWriter.Close()
 	multiWriter := io.MultiWriter(logWriter, azureWriter)
 	maskWriter := logstream.NewMasker(multiWriter, secretData)
 
@@ -118,9 +118,10 @@ func (tes *testExecutionService) Run(ctx context.Context,
 		tes.logger.Errorf("failed to find process for command %s with pid %d %v", cmd.String(), pid, err)
 		return nil, err
 	}
-	if err := cmd.Wait(); err != nil {
-		tes.logger.Errorf("Error in executing []: %+v\n", err)
-		return nil, err
+
+	errC := cmd.Wait()
+	if errC != nil {
+		tes.logger.Errorf("Error in executing []: %+v\n", errC)
 	}
 	executionResults := <-tes.ts.ExecutionResultOutputChannel
 
@@ -131,12 +132,16 @@ func (tes *testExecutionService) Run(ctx context.Context,
 	// 		return nil, err
 	// 	}
 	// }
+	return &executionResults, errC
+}
+
+func (tes *testExecutionService) closeAndWriteLog(azureWriter *io.PipeWriter, errChan <-chan error) error {
 	azureWriter.Close()
-	if uploadErr := <-errChan; uploadErr != nil {
-		tes.logger.Errorf("failed to upload logs for test execution, error: %v", uploadErr)
-		return nil, uploadErr
+	if err := <-errChan; err != nil {
+		tes.logger.Errorf("failed to upload logs for test execution, error: %v", err)
+		return err
 	}
-	return &executionResults, nil
+	return nil
 }
 
 // func (tes *testExecutionService) createCoverageManifest(tasConfig *core.TASConfig, coverageDirectory string, removedFiles []string, executeAll bool) error {


### PR DESCRIPTION
# Description

This diff includes changes for marking the current _task_ as "Failed" instead of "TAS Error" on TAS whenever there's an end-user induced errors like invalid `.tas.yml` file, incorrect preRun steps, syntax error in code, test-failures etc. Earlier, these errors were marked as "TAS Error"; but these errors are essentially "Failed" tasks as they're user-driven.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally on TAS stage:
1. Webhook with incorrect `.tas.yml` file. Got status as "Failed".
2. Webhook with failing tests. Got status as "Failed".

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
