### PR TITLE
#116: Added check for checking a linked issue first before raising a PR.

### DIFF
--- a/.github/workflows/pull_request_lint.yml
+++ b/.github/workflows/pull_request_lint.yml
@@ -1,0 +1,22 @@
+name: Pull Request Lint
+
+on:
+  pull_request:
+    types: ['opened', 'edited', 'reopened', 'synchronize']
+    branches-ignore: [beta, main]
+
+jobs:
+  title:
+    name: ticket check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for ticket
+        uses: neofinancial/ticket-check-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ticketLink: 'https://github.com/LambdaTest/test-at-scale/issues/%ticketNumber%'
+          ticketPrefix: '#'
+          titleRegex: '^#(?<ticketNumber>\d+)'
+          bodyRegex: '#(?<ticketNumber>\d+)'
+          bodyURLRegex: 'http(s?):\/\/(github.com)(\/LambdaTest)(\/test-at-scale)(\/issues)\/(?<ticketNumber>\d+)'


### PR DESCRIPTION
# Issue Link

https://github.com/LambdaTest/test-at-scale/issues/116

# Description

This diff adds hard check for validating that the pull requests contain an associated issue.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This has been tested in this PR only : 
1. by raising the PR without an open issue and observing the error message and status check
2. by editing the PR description and observing the error message and status check
