### PR TITLE
#102: Fix - Made nodeVersion field optional

### DIFF
--- a/pkg/core/models.go
+++ b/pkg/core/models.go
@@ -295,7 +295,7 @@ type TASConfig struct {
 	ConfigFile        string             `yaml:"configFile" validate:"omitempty"`
 	CoverageThreshold *CoverageThreshold `yaml:"coverageThreshold" validate:"omitempty"`
 	Tier              Tier               `yaml:"tier" validate:"oneof=xsmall small medium large xlarge"`
-	NodeVersion       string             `yaml:"nodeVersion" validate:"semver"`
+	NodeVersion       string             `yaml:"nodeVersion" validate:"omitempty,semver"`
 	ContainerImage    string             `yaml:"containerImage"`
 }
 

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -192,6 +192,16 @@ func TestValidateStruct(t *testing.T) {
 				Tier:        "small",
 			},
 		},
+		{
+			"Valid Config - Only Framework",
+			"testutils/testdata/tasyml/framework_only_required.yml",
+			nil,
+			&core.TASConfig{
+				SmartRun:  true,
+				Framework: "mocha",
+				Tier:      "small",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/testutils/testdata/tasyml/framework_only_required.yml
+++ b/testutils/testdata/tasyml/framework_only_required.yml
@@ -1,0 +1,1 @@
+framework: mocha


### PR DESCRIPTION
# Issue Link

https://github.com/LambdaTest/test-at-scale/issues/102

# Description

Fix - Made nodeVersion field optional

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a UT for the issue.
Without this diff, UT fails.
With this diff, UT passes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
