### PR TITLE
support for build cache cleanup

### DIFF
--- a/cmd/synapse/bin.go
+++ b/cmd/synapse/bin.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/LambdaTest/test-at-scale/config"
+	"github.com/LambdaTest/test-at-scale/pkg/cron"
 	"github.com/LambdaTest/test-at-scale/pkg/global"
 	"github.com/LambdaTest/test-at-scale/pkg/lumber"
 	"github.com/LambdaTest/test-at-scale/pkg/proxyserver"
@@ -94,6 +95,10 @@ func run(cmd *cobra.Command, args []string) {
 	if err != nil {
 		logger.Fatalf("Could not instantiate proxyhandler %v", err)
 	}
+
+	// setting up cron handler
+	wg.Add(1)
+	go cron.Setup(ctx, &wg, logger)
 
 	// All attempts to connect to lambdatest server failed
 	connectionFailed := make(chan struct{})

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -738,6 +738,8 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/cron/setup.go
+++ b/pkg/cron/setup.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	buildCacheExpiry time.Duration = 1 * time.Minute
+	buildCacheExpiry time.Duration = 4 * time.Hour
 	buildCacheDir    string        = "/tmp/synapse"
 )
 
@@ -22,7 +22,7 @@ func Setup(ctx context.Context, wg *sync.WaitGroup, logger lumber.Logger) {
 	defer wg.Done()
 
 	c := cron.New()
-	if _, err := c.AddFunc("@every 1m", func() { cleanupBuildCache(logger) }); err != nil {
+	if _, err := c.AddFunc("@every 5m", func() { cleanupBuildCache(logger) }); err != nil {
 		logger.Errorf("error setting up cron")
 		return
 	}

--- a/pkg/cron/setup.go
+++ b/pkg/cron/setup.go
@@ -1,0 +1,54 @@
+package cron
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"sync"
+	"time"
+
+	"github.com/LambdaTest/test-at-scale/pkg/lumber"
+	"github.com/LambdaTest/test-at-scale/pkg/utils"
+	"github.com/robfig/cron/v3"
+)
+
+const (
+	buildCacheExpiry time.Duration = 4 * time.Hour
+	buildCacheDir    string        = "/tmp/synapse"
+)
+
+// Setup initializes all crons on service startup
+func Setup(ctx context.Context, wg *sync.WaitGroup, logger lumber.Logger) {
+	defer wg.Done()
+
+	c := cron.New()
+	if _, err := c.AddFunc("@every 5m", func() { cleanupBuildCache(logger) }); err != nil {
+		logger.Errorf("error setting up cron")
+		return
+	}
+	c.Start()
+
+	select {
+	case <-ctx.Done():
+		c.Stop()
+		logger.Infof("Caller has requested graceful shutdown. Returning.....")
+		return
+	}
+}
+
+func cleanupBuildCache(logger lumber.Logger) {
+	files, err := ioutil.ReadDir(buildCacheDir)
+	if err != nil {
+		logger.Errorf("error in reading directory: %s", err)
+		return
+	}
+	for _, file := range files {
+		now := time.Now()
+		if diff := now.Sub(file.ModTime()); diff > buildCacheExpiry {
+			filePath := fmt.Sprintf("%s/%s", buildCacheDir, file.Name())
+			if err := utils.DeleteDirectory(filePath); err != nil {
+				logger.Errorf("error deleting directory: %s", err.Error())
+			}
+		}
+	}
+}

--- a/pkg/errs/synapse.go
+++ b/pkg/errs/synapse.go
@@ -166,6 +166,13 @@ func ERR_DIR_CRT(err string) Err {
 		Message: fmt.Sprintf("Unable to create directory :  \n%s", err)}
 }
 
+// ERR_DIR_DEL function returns error with code "ERR::DIR::DEL"
+func ERR_DIR_DEL(err string) Err {
+	return Err{
+		Code:    "ERR::DIR::DEL",
+		Message: fmt.Sprintf("Unable to delete directory :  \n%s", err)}
+}
+
 // ERR_FIL_CRT function returns error with code ERR::FIL::CRT
 func ERR_FIL_CRT(err string) Err {
 	return Err{

--- a/pkg/errs/synapse.go
+++ b/pkg/errs/synapse.go
@@ -166,8 +166,8 @@ func ERR_DIR_CRT(err string) Err {
 		Message: fmt.Sprintf("Unable to create directory :  \n%s", err)}
 }
 
-// ERR_DIR_DEL function returns error with code "ERR::DIR::DEL"
-func ERR_DIR_DEL(err string) Err {
+// ErrDirDel function returns error with code "ERR::DIR::DEL"
+func ErrDirDel(err string) Err {
 	return Err{
 		Code:    "ERR::DIR::DEL",
 		Message: fmt.Sprintf("Unable to delete directory :  \n%s", err)}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -75,6 +75,14 @@ func CreateDirectory(path string) error {
 	return nil
 }
 
+// DeleteDirectory deletes directory and all its children
+func DeleteDirectory(path string) error {
+	if err := os.RemoveAll(path); err != nil {
+		return errs.ERR_DIR_DEL(err.Error())
+	}
+	return nil
+}
+
 // WriteFileToDirectory writes `data` file to `filename`/`path`
 func WriteFileToDirectory(path, filename string, data []byte) error {
 	location := fmt.Sprintf("%s/%s", path, filename)

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -78,7 +78,7 @@ func CreateDirectory(path string) error {
 // DeleteDirectory deletes directory and all its children
 func DeleteDirectory(path string) error {
 	if err := os.RemoveAll(path); err != nil {
-		return errs.ERR_DIR_DEL(err.Error())
+		return errs.ErrDirDel(err.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
# Issue Link

#174 

# Description

All build containers are mounting /tmp/synapse that is used to store build cache. Which is filling the storage.
As a fix we have added cron mechanism which cleans up buildCache folder every 4 hours.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Reduced cache expiry time to 1 minute and tested by creating multiple folders

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
