### PR TITLE
Use `os.{Lstat,ReadDir}` instead of `os.Stat` and `ioutil.ReadDir`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/joho/godotenv v1.4.0
 	github.com/mholt/archiver/v3 v3.5.1
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/shirou/gopsutil/v3 v3.21.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
@@ -66,7 +67,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/spf13/afero v1.6.0 // indirect
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/pkg/secret/secret.go
+++ b/pkg/secret/secret.go
@@ -30,7 +30,7 @@ func New(logger lumber.Logger) core.SecretParser {
 // GetRepoSecret read repo secrets from given path
 func (s *secretParser) GetRepoSecret(path string) (map[string]string, error) {
 	var secretData map[string]string
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	if _, err := os.Lstat(path); os.IsNotExist(err) {
 		s.logger.Debugf("failed to find user env secrets in path %s, as path does not exists", path)
 		return nil, nil
 	}
@@ -53,7 +53,7 @@ func (s *secretParser) GetOauthSecret(path string) (*core.Oauth, error) {
 	o := &core.Oauth{
 		Type: core.Bearer,
 	}
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	if _, err := os.Lstat(path); os.IsNotExist(err) {
 		s.logger.Errorf("failed to find oauth secret in path %s", path)
 		return nil, err
 	}

--- a/pkg/secrets/secrets_test.go
+++ b/pkg/secrets/secrets_test.go
@@ -29,7 +29,7 @@ func TestWriteGitSecrets(t *testing.T) {
 	if err != nil {
 		t.Errorf("error while writing secrets: %v", err)
 	}
-	if _, errS := os.Stat(expectedFile); errS != nil {
+	if _, errS := os.Lstat(expectedFile); errS != nil {
 		t.Errorf("could not find the git config file: %v", errS)
 	}
 

--- a/pkg/service/coverage/coverage.go
+++ b/pkg/service/coverage/coverage.go
@@ -53,7 +53,7 @@ func New(execManager core.ExecutionManager,
 	if !cfg.CoverageMode {
 		return nil, nil
 	}
-	if _, err := os.Stat(global.CodeCoverageDir); os.IsNotExist(err) {
+	if _, err := os.Lstat(global.CodeCoverageDir); os.IsNotExist(err) {
 		return nil, errors.New("coverage directory not mounted")
 	}
 	return &codeCoverageService{
@@ -71,7 +71,7 @@ func New(execManager core.ExecutionManager,
 
 //mergeCodeCoverageFiles merge all the coverage.json into single entity
 func (c *codeCoverageService) mergeCodeCoverageFiles(ctx context.Context, commitDir, coverageManifestPath string, threshold bool) error {
-	if _, err := os.Stat(commitDir); os.IsNotExist(err) {
+	if _, err := os.Lstat(commitDir); os.IsNotExist(err) {
 		c.logger.Errorf("coverage files not found, skipping merge")
 		return nil
 	}
@@ -125,7 +125,7 @@ func (c *codeCoverageService) MergeAndUpload(ctx context.Context, payload *core.
 		commitDir := filepath.Join(repoDir, commit.Sha)
 		c.logger.Debugf("commit directory %s", commitDir)
 
-		if _, err := os.Stat(commitDir); os.IsNotExist(err) {
+		if _, err := os.Lstat(commitDir); os.IsNotExist(err) {
 			c.logger.Errorf("code coverage directory not found commit id %s", commit.Sha)
 			return err
 		}
@@ -202,7 +202,7 @@ func (c *codeCoverageService) uploadFile(ctx context.Context, blobPath, filename
 
 func (c *codeCoverageService) parseManifestFile(filepath string) (core.CoverageManifest, error) {
 	manifestPayload := core.CoverageManifest{}
-	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+	if _, err := os.Lstat(filepath); os.IsNotExist(err) {
 		c.logger.Errorf("manifest file not found in path %s", filepath)
 		return manifestPayload, err
 	}
@@ -268,7 +268,7 @@ func (c *codeCoverageService) downloadAndDecompressParentCommitDir(ctx context.C
 }
 
 func (c *codeCoverageService) copyFromParentCommitDir(parentCommitDir, commitDir string, removedFiles ...string) error {
-	if _, err := os.Stat(parentCommitDir); os.IsNotExist(err) {
+	if _, err := os.Lstat(parentCommitDir); os.IsNotExist(err) {
 		c.logger.Errorf("Parent Commit Directory %s not found", parentCommitDir)
 		return err
 	}
@@ -288,7 +288,7 @@ func (c *codeCoverageService) copyFromParentCommitDir(parentCommitDir, commitDir
 
 			//TODO: check if copied dir size is not 0
 			//if file already exists then don't copy from parent directory
-			if _, err := os.Stat(testfileDir); os.IsNotExist(err) {
+			if _, err := os.Lstat(testfileDir); os.IsNotExist(err) {
 				if err := fileutils.CopyDir(path, testfileDir, false); err != nil {
 					c.logger.Errorf("failed to copy directory from src %s to dest %s, error %v", path, testfileDir, err)
 					return err
@@ -376,7 +376,7 @@ func (c *codeCoverageService) sendCoverageData(payload []coverageData) error {
 }
 
 func (c *codeCoverageService) getTotalCoverage(filepath string) (json.RawMessage, error) {
-	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+	if _, err := os.Lstat(filepath); os.IsNotExist(err) {
 		c.logger.Errorf("coverage summary file not found in path %s", filepath)
 		return nil, err
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -67,7 +67,7 @@ func InterfaceToMap(in interface{}) map[string]string {
 
 // CreateDirectory creates directory recursively if does not exists
 func CreateDirectory(path string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
+	if _, err := os.Lstat(path); os.IsNotExist(err) {
 		if err := os.MkdirAll(path, global.DirectoryPermissions); err != nil {
 			return errs.ERR_DIR_CRT(err.Error())
 		}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -94,7 +94,7 @@ func TestCreateDirectory(t *testing.T) {
 				return
 			}
 			if tt.args.path == newDir {
-				if _, err := os.Stat(newDir); err != nil {
+				if _, err := os.Lstat(newDir); err != nil {
 					t.Errorf("Directory did not exist, error: %v", err)
 					return
 				}


### PR DESCRIPTION
Signed-off-by: subham sarkar <sarkar.subhams2@gmail.com>

# Description
Replace calls and make some related modifications. Also, tidy up modules (`go mod tidy`).

Replacements:
1. os.Stat -> os.Lstat as there's no symlink following (as per comments); so lstat is preferred over stat calls.
2. ioutil.ReadDir -> os.ReadDir. Why? Here: https://github.com/golang/go/issues/41467 


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
```
go test -vet=off ./...
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
