### PR TITLE
Fix aborting jobs on synapse with parallelism

### DIFF
--- a/pkg/runner/docker/docker.go
+++ b/pkg/runner/docker/docker.go
@@ -345,7 +345,6 @@ func (d *docker) KillContainerForBuildID(buildID string) error {
 				d.logger.Errorf("error while destroying container: %v", err)
 				return err
 			}
-			return nil
 		}
 	}
 	return nil


### PR DESCRIPTION

# Issue Link

https://github.com/LambdaTest/test-at-scale/issues/228

# Description

All running docker containers for a buildID should be killed when aborting a build (for example in case of parallelism)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested by running build with parallelism on synapse and calling abort.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
